### PR TITLE
Add AUR package to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ $ cd ghtopdep
 $ python setup.py install
 ```
 
+from Arch User Repository (if you're using Arch Linux)
+
+```
+$ git clone https://aur.archlinux.org/python-ghtopdep.git
+$ cd python-ghtopdep
+$ makepkg -si
+```
+
 ## Python development Installation
 
 Ubuntu/Debian


### PR DESCRIPTION
Add the AUR package to the README for the comfort of Arch users (https://aur.archlinux.org/packages/python-ghtopdep)