### PR TITLE
Add Dockerfile for usage with Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM python:3.10-alpine
+
+WORKDIR /app
+
+# Install build dependencies (gcc, etc.)
+RUN apk update \
+    && apk --no-cache --update add build-base libffi-dev openssl-dev
+
+# Set poetry version to use
+ARG POETRY_VERSION=1.4.0
+# Prevent Python from generating .pyc files
+ENV PYTHONDONTWRITEBYTECODE 1
+# Turn off stdout/stderr buffering to make output appear in real time
+ENV PYTHONUNBUFFERED 1
+# Set pip env vars for faster/leaner docker builds
+ENV PIP_DEFAULT_TIMEOUT=100 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1
+
+RUN pip install "poetry==$POETRY_VERSION"
+
+# Install dependencies first to leverage Docker layer caching
+ADD poetry.lock pyproject.toml ./
+
+RUN poetry config virtualenvs.create false \
+    && poetry install --no-interaction --no-ansi
+
+# After dependencies are installed, copy the rest of the code
+ADD . .
+
+ENTRYPOINT ["python", "main.py"]

--- a/README.md
+++ b/README.md
@@ -13,19 +13,19 @@ CLI tool for sorting dependents repo by stars
 
 ## Installation
 
-from PyPI
+### From PyPI
 
 ```sh
 $ pip install ghtopdep
 ```
 
-from git repository
+### From git repository
 
 ```sh
 $ pip install git+https://github.com/github-tooling/ghtopdep.git#egg=ghtopdep
 ```
 
-from source
+### From source
 
 ```sh
 $ git clone https://github.com/github-tooling/ghtopdep
@@ -33,15 +33,31 @@ $ cd ghtopdep
 $ python setup.py install
 ```
 
+### Using docker (from source)
+
+First `docker build` the image once:
+
+```sh
+$ git clone https://github.com/github-tooling/ghtopdep
+$ cd ghtopdep
+$ docker build . -t ghtopdep
+```
+
+Then you can `docker run` it:
+
+```sh
+$ docker run --rm -it ghtopdep --help
+```
+
 ## Python development Installation
 
-Ubuntu/Debian
+### Ubuntu/Debian
 
 ```sh
 sudo apt install python3-dev
 ```
 
-CentOS/RHEL
+### CentOS/RHEL
 
 ```sh
 sudo yum install python3-devel
@@ -84,7 +100,7 @@ Options:
   --help                       Show this message and exit.
 ```
 
-Table view (by default)
+### Table view (by default)
 
 ```sh
 ➜ ghtopdep https://github.com/dropbox/dropbox-sdk-js
@@ -105,7 +121,7 @@ found 443 repositories with more than zero star
 ~ via ⬢ v12.5.0 via 🐘 v7.2.19 via 🐍 3.8.0 took 2m 57s
 ```
 
-JSON view
+### JSON view
 
 ```sh
 ➜ ghtopdep https://github.com/dropbox/dropbox-sdk-js --json

--- a/README.md
+++ b/README.md
@@ -15,19 +15,19 @@ CLI tool for sorting dependents repo by stars
 
 from PyPI
 
-```
+```sh
 $ pip install ghtopdep
 ```
 
 from git repository
 
-```
+```sh
 $ pip install git+https://github.com/github-tooling/ghtopdep.git#egg=ghtopdep
 ```
 
 from source
 
-```
+```sh
 $ git clone https://github.com/github-tooling/ghtopdep
 $ cd ghtopdep
 $ python setup.py install
@@ -37,19 +37,19 @@ $ python setup.py install
 
 Ubuntu/Debian
 
-```
+```sh
 sudo apt install python3-dev
 ```
 
 CentOS/RHEL
 
-```
+```sh
 sudo yum install python3-devel
 ```
 
 ## Version upgrade
 
-```
+```sh
 ➜ pip install --upgrade ghtopdep
 ```
 
@@ -66,7 +66,7 @@ export GHTOPDEP_TOKEN="**\*\*\*\***\*\***\*\*\*\***\*\*\*\***\*\*\*\***\*\***\*\
 
 or pass token as option --token
 
-```
+```sh
 ➜ ghtopdep --help
 Usage: ghtopdep [OPTIONS] URL
 
@@ -86,7 +86,7 @@ Options:
 
 Table view (by default)
 
-```
+```sh
 ➜ ghtopdep https://github.com/dropbox/dropbox-sdk-js
 | url                                               | stars   |
 |---------------------------------------------------|---------|
@@ -107,14 +107,14 @@ found 443 repositories with more than zero star
 
 JSON view
 
-```
+```sh
 ➜ ghtopdep https://github.com/dropbox/dropbox-sdk-js --json
 [{"url": "https://github.com/transloadit/uppy", "stars": 21191}, {"url": "https://github.com/codesandbox/codesandbox-client", "stars": 8386}, {"url": "https://github.com/joemccann/dillinger", "stars": 6491}, {"url": "https://github.com/keplergl/kepler.gl", "stars": 5615}, {"url": "https://github.com/jitsi/jitsi-meet", "stars": 4303}, {"url": "https://github.com/jsbin/jsbin", "stars": 3947}, {"url": "https://github.com/NorthwoodsSoftware/GoJS", "stars": 3692}, {"url": "https://github.com/buttercup/buttercup-desktop", "stars": 3054}, {"url": "https://github.com/openstyles/stylus", "stars": 2219}, {"url": "https://github.com/mickael-kerjean/filestash", "stars": 1869}]
 ```
 
 you can sort packages and fetch their description
 
-```
+```sh
 ➜ ghtopdep https://github.com/dropbox/dropbox-sdk-js --description --packages
 | url                                            | stars   | description                                                  |
 |------------------------------------------------|---------|--------------------------------------------------------------|
@@ -134,7 +134,7 @@ found 61 packages with more than zero star
 
 also ghtopdep support code searching at dependents (repositories/packages)
 
-```
+```sh
 ➜ ghtopdep https://github.com/rob-balfre/svelte-select --search=isMulti --minstar=0
 https://github.com/andriyor/linkorg-frontend/blob/7eed49c332f127c8541281b85def80e54c882920/src/App.svelte with 0 stars
 https://github.com/andriyor/linkorg-frontend/blob/7eed49c332f127c8541281b85def80e54c882920/src/providers/Post.svelte with 0 stars
@@ -149,7 +149,7 @@ https://github.com/wolbodo/members/blob/d091f1e44b4e8cb8cc31f39ea6f6e9c36211d019
 
 Using [Poetry](https://poetry.eustace.io/docs/)
 
-```
+```sh
 $ poetry install
 $ poetry run ghtopdep https://github.com/dropbox/dropbox-sdk-js
 $ dephell deps convert --from=pyproject.toml --to=setup.py
@@ -161,7 +161,7 @@ $ poetry publish
 
 or [Pipenv](https://docs.pipenv.org/)
 
-```
+```sh
 $ pipenv install --dev -e .
 ```
 

--- a/main.py
+++ b/main.py
@@ -1,0 +1,4 @@
+from ghtopdep.ghtopdep import cli
+
+if __name__ == "__main__":
+    cli(prog_name="ghtopdep")


### PR DESCRIPTION
By adding a Dockerfile to the project, users can easily run the application without needing to set up a local environment or install dependencies. This makes it faster and easier to start using it, especially for people not familiar with Python development.

Partially solves https://github.com/github-tooling/ghtopdep/issues/14: users can now build a Docker image locally and use it that way, but it might still be nice to publish it to Docker Hub too at some point (which would let people use the app without needing to clone the repo first).