### PR TITLE
feat: port dep-rank internal enhancements (no CLI changes)

### DIFF
--- a/ghtopdep/ghtopdep.py
+++ b/ghtopdep/ghtopdep.py
@@ -1,6 +1,7 @@
 import calendar
 import json
 import os
+import re
 import sys
 import textwrap
 import datetime
@@ -111,6 +112,21 @@ def get_max_deps(sess, url):
     deps_count_element = parsed_node.css_first('.table-list-header-toggle .btn-link.selected')
     max_deps = int(deps_count_element.text().strip().split()[0].replace(',', ''))
     return max_deps
+
+
+def parse_dependent_counts(html):
+    """Extract repo/package dependent counts from a dependents page."""
+    tree = HTMLParser(html)
+    counts = {}
+    for link in tree.css("div.table-list-header-toggle a.btn-link"):
+        text = link.text(strip=True)
+        match = re.match(r"([\d,]+)\s+(Repositor(?:ies|y)|Packages?)\s*$", text)
+        if match:
+            count = int(match.group(1).replace(",", ""))
+            kind = match.group(2)
+            key = "REPOSITORY" if kind.startswith("Repositor") else "PACKAGE"
+            counts[key] = count
+    return counts
 
 
 @click.command()

--- a/ghtopdep/ghtopdep.py
+++ b/ghtopdep/ghtopdep.py
@@ -3,7 +3,6 @@ import json
 import os
 import re
 import sys
-import textwrap
 import datetime
 from email.utils import formatdate, parsedate
 from urllib.parse import urlparse
@@ -22,6 +21,9 @@ from selectolax.parser import HTMLParser
 from tabulate import tabulate
 
 from ghtopdep import __version__
+from ghtopdep.rate_limiter import TokenBucketRateLimiter
+from ghtopdep.graphql_enrich import enrich_descriptions
+from ghtopdep.prefetch import PagePrefetcher
 
 PACKAGE_NAME = "ghtopdep"
 CACHE_DIR = appdirs.user_cache_dir(PACKAGE_NAME)
@@ -53,21 +55,6 @@ class OneDayHeuristic(BaseHeuristic):
     def warning(self, response):
         msg = "Automatically cached! Response is Stale."
         return "110 - {0}".format(msg)
-
-
-def already_added(repo_url, repos):
-    for repo in repos:
-        if repo['url'] == repo_url:
-            return True
-
-
-def fetch_description(gh, relative_url):
-    _, owner, repository = relative_url.split("/")
-    repository = gh.repository(owner, repository)
-    repo_description = " "
-    if repository.description:
-        repo_description = textwrap.shorten(repository.description, width=60, placeholder="...")
-    return repo_description
 
 
 def sort_repos(repos, rows):
@@ -103,15 +90,6 @@ def show_result(repos, total_repos_count, more_than_zero_count, destinations, ta
             click.echo("Doesn't find any {0} that match search request".format(destinations))
     else:
         click.echo(json.dumps(repos))
-
-
-def get_max_deps(sess, url):
-    main_response = sess.get(url)
-    parsed_node = HTMLParser(main_response.text)
-
-    deps_count_element = parsed_node.css_first('.table-list-header-toggle .btn-link.selected')
-    max_deps = int(deps_count_element.text().strip().split()[0].replace(',', ''))
-    return max_deps
 
 
 def parse_dependent_counts(html):
@@ -159,14 +137,16 @@ def cli(url, repositories, search, table, rows, minstar, report, description, to
         except requests.exceptions.ConnectionError as e:
             click.echo(e)
 
-    if (description or search) and token:
+    if (description or search) and not token:
+        click.echo("Please provide token")
+        sys.exit()
+
+    gh = None
+    if search and token:
         gh = github3.login(token=token)
         CacheControl(gh.session,
                      cache=FileCache(CACHE_DIR),
                      heuristic=OneDayHeuristic())
-    elif (description or search) and not token:
-        click.echo("Please provide token")
-        sys.exit()
 
     destination = "repository"
     destinations = "repositories"
@@ -175,29 +155,42 @@ def cli(url, repositories, search, table, rows, minstar, report, description, to
         destinations = "packages"
 
     repos = []
+    seen_urls = set()
     more_than_zero_count = 0
     total_repos_count = 0
 
     sess = requests.session()
     retries = Retry(
-        total=15,
-        backoff_factor=15,
-        status_forcelist=[429])
+        total=5,
+        backoff_factor=5,
+        backoff_max=120,
+        status_forcelist=[429, 500, 502, 503])
     adapter = CacheControlAdapter(max_retries=retries,
                                   cache=FileCache(CACHE_DIR),
                                   heuristic=OneDayHeuristic())
     sess.mount("http://", adapter)
     sess.mount("https://", adapter)
 
-    page_url = "{0}/network/dependents?dependent_type={1}".format(url, destination.upper())
-    
-    max_deps = get_max_deps(sess, page_url)
+    limiter = TokenBucketRateLimiter(
+        rate=60 if token else 10,
+        period=60.0
+    )
+    prefetcher = PagePrefetcher(sess, limiter)
 
-    pbar = tqdm(total=max_deps)
+    page_url = "{0}/network/dependents?dependent_type={1}".format(url, destination.upper())
+
+    pbar = None
 
     while True:
-        response = sess.get(page_url)
-        parsed_node = HTMLParser(response.text)
+        html = prefetcher.get(page_url)
+        parsed_node = HTMLParser(html)
+
+        if pbar is None:
+            counts = parse_dependent_counts(html)
+            dep_type_key = destination.upper()
+            max_deps = counts.get(dep_type_key, 0)
+            pbar = tqdm(total=max_deps if max_deps > 0 else None)
+
         dependents = parsed_node.css(ITEM_SELECTOR)
         total_repos_count += len(dependents)
         for dep in dependents:
@@ -215,34 +208,32 @@ def cli(url, repositories, search, table, rows, minstar, report, description, to
                 relative_repo_url = dep.css(REPO_SELECTOR)[0].attributes["href"]
                 repo_url = "{0}{1}".format(GITHUB_URL, relative_repo_url)
 
-                # can be listed same package
-                is_already_added = already_added(repo_url, repos)
-                if not is_already_added and repo_url != url:
-                    if description:
-                        repo_description = fetch_description(gh, relative_repo_url)
-                        repos.append({
-                            "url": repo_url,
-                            "stars": repo_stars_num,
-                            "description": repo_description
-                        })
-                    else:
-                        repos.append({
-                            "url": repo_url,
-                            "stars": repo_stars_num
-                        })
+                if repo_url not in seen_urls and repo_url != url:
+                    seen_urls.add(repo_url)
+                    repos.append({
+                        "url": repo_url,
+                        "stars": repo_stars_num
+                    })
 
         pagination_buttons = parsed_node.css(NEXT_BUTTON_SELECTOR)
 
+        next_page_url = None
         if len(pagination_buttons) == 2:
-            page_url = pagination_buttons[1].attributes["href"]
+            next_page_url = pagination_buttons[1].attributes["href"]
         elif pagination_buttons and pagination_buttons[0].text() == "Next":
-            page_url = pagination_buttons[0].attributes["href"]
-        elif len(pagination_buttons) == 0 or pagination_buttons[0].text() == "Previous":
-            break
+            next_page_url = pagination_buttons[0].attributes["href"]
 
         pbar.update(REPOS_PER_PAGE)
 
-    pbar.close()
+        if next_page_url is None:
+            break
+
+        prefetcher.submit(next_page_url)
+        page_url = next_page_url
+
+    prefetcher.shutdown()
+    if pbar is not None:
+        pbar.close()
 
     if report:
         try:
@@ -251,6 +242,9 @@ def cli(url, repositories, search, table, rows, minstar, report, description, to
             click.echo(e)
 
     sorted_repos = sort_repos(repos, rows)
+
+    if description:
+        sorted_repos = enrich_descriptions(sess, sorted_repos, token)
 
     if search:
         for repo in repos:

--- a/ghtopdep/graphql_enrich.py
+++ b/ghtopdep/graphql_enrich.py
@@ -1,0 +1,82 @@
+import textwrap
+from urllib.parse import urlparse
+
+import requests
+
+GRAPHQL_URL = "https://api.github.com/graphql"
+BATCH_SIZE = 100
+
+
+def build_batch_query(repos):
+    """Build a GraphQL query to fetch stargazerCount and description for repos.
+
+    Args:
+        repos: List of dicts with "url" key (e.g., "https://github.com/owner/name").
+
+    Returns:
+        GraphQL query string.
+    """
+    fragments = []
+    for i, repo in enumerate(repos):
+        path = urlparse(repo["url"]).path.strip("/")
+        owner, name = path.split("/")
+        fragments.append(
+            'repo_{0}: repository(owner: "{1}", name: "{2}") '
+            '{{ stargazerCount description }}'.format(i, owner, name)
+        )
+    return "query { " + " ".join(fragments) + " }"
+
+
+def enrich_descriptions(session, repos, token):
+    """Fetch descriptions via GitHub GraphQL API in batches of 100.
+
+    Args:
+        session: requests.Session instance.
+        repos: List of repo dicts (already sorted top-N).
+        token: GitHub API token string.
+
+    Returns:
+        New list of dicts with "description" key added.
+        Falls back to the original list on any error.
+    """
+    if not repos:
+        return repos
+
+    enriched = []
+    headers = {
+        "Authorization": "bearer {0}".format(token),
+        "Content-Type": "application/json",
+    }
+
+    for batch_start in range(0, len(repos), BATCH_SIZE):
+        batch = repos[batch_start:batch_start + BATCH_SIZE]
+        query = build_batch_query(batch)
+
+        try:
+            resp = session.post(
+                GRAPHQL_URL,
+                json={"query": query},
+                headers=headers,
+            )
+        except requests.RequestException:
+            return repos
+
+        if resp.status_code != 200:
+            return repos
+
+        data = resp.json()
+        if "data" not in data:
+            return repos
+
+        for i, repo in enumerate(batch):
+            repo_data = data["data"].get("repo_{0}".format(i))
+            new_repo = dict(repo)
+            if repo_data and repo_data.get("description"):
+                new_repo["description"] = textwrap.shorten(
+                    repo_data["description"], width=60, placeholder="..."
+                )
+            else:
+                new_repo["description"] = " "
+            enriched.append(new_repo)
+
+    return enriched

--- a/ghtopdep/prefetch.py
+++ b/ghtopdep/prefetch.py
@@ -1,0 +1,53 @@
+from concurrent.futures import ThreadPoolExecutor
+
+
+class PagePrefetcher:
+    """Threaded single-page-ahead prefetcher.
+
+    Fetches the next page in a background thread while the main
+    thread processes the current page.
+
+    Args:
+        session: requests.Session (thread-safe).
+        limiter: TokenBucketRateLimiter (thread-safe via lock).
+    """
+
+    def __init__(self, session, limiter):
+        self._session = session
+        self._limiter = limiter
+        self._executor = ThreadPoolExecutor(max_workers=1)
+        self._pending = None
+
+    def submit(self, url):
+        """Start fetching url in a background thread.
+
+        Only one prefetch at a time. If a prefetch is already
+        pending, this call is a no-op.
+        """
+        if self._pending is not None:
+            return
+        self._pending = self._executor.submit(self._fetch, url)
+
+    def get(self, url):
+        """Return prefetched result if available, or fetch url synchronously.
+
+        The caller must ensure get() is called for the same URL that
+        was submitted. The url param is only used for the synchronous
+        fallback path (no pending prefetch).
+        """
+        if self._pending is not None:
+            result = self._pending.result()
+            self._pending = None
+            return result
+        return self._fetch(url)
+
+    def shutdown(self):
+        """Cancel any pending prefetch and shut down the thread pool."""
+        if self._pending is not None:
+            self._pending.cancel()
+        self._executor.shutdown(wait=False)
+
+    def _fetch(self, url):
+        self._limiter.acquire()
+        response = self._session.get(url)
+        return response.text

--- a/ghtopdep/rate_limiter.py
+++ b/ghtopdep/rate_limiter.py
@@ -1,0 +1,37 @@
+import threading
+import time
+
+
+class TokenBucketRateLimiter:
+    """Synchronous, thread-safe token bucket rate limiter.
+
+    Args:
+        rate: Maximum requests allowed per period.
+        period: Time period in seconds.
+    """
+
+    def __init__(self, rate, period):
+        self._rate = rate
+        self._period = period
+        self._tokens = float(rate)
+        self._last_refill = time.monotonic()
+        self._lock = threading.Lock()
+
+    def acquire(self):
+        """Block until a token is available, then consume it."""
+        with self._lock:
+            self._refill()
+            if self._tokens < 1.0:
+                wait_time = (1.0 - self._tokens) * (self._period / self._rate)
+                time.sleep(wait_time)
+                self._refill()
+            self._tokens -= 1.0
+
+    def _refill(self):
+        now = time.monotonic()
+        elapsed = now - self._last_refill
+        self._tokens = min(
+            float(self._rate),
+            self._tokens + elapsed * (self._rate / self._period),
+        )
+        self._last_refill = now

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ tqdm = "^4.66.4"
 [tool.poetry.dev-dependencies]
 better_exceptions = "^0.2.2"
 pysnooper = "^0.3.0"
+pytest = "^7.0"
 
 [tool.poetry.scripts]
 ghtopdep = 'ghtopdep.ghtopdep:cli'

--- a/tests/test_graphql_enrich.py
+++ b/tests/test_graphql_enrich.py
@@ -1,0 +1,124 @@
+from unittest.mock import MagicMock
+from ghtopdep.graphql_enrich import build_batch_query, enrich_descriptions
+
+
+def test_build_batch_query_single_repo():
+    repos = [{"url": "https://github.com/facebook/react", "stars": 200000}]
+    query = build_batch_query(repos)
+    assert "repo_0" in query
+    assert 'owner: "facebook"' in query
+    assert 'name: "react"' in query
+    assert "stargazerCount" in query
+    assert "description" in query
+
+
+def test_build_batch_query_multiple_repos():
+    repos = [
+        {"url": "https://github.com/facebook/react", "stars": 200000},
+        {"url": "https://github.com/vuejs/vue", "stars": 180000},
+    ]
+    query = build_batch_query(repos)
+    assert "repo_0" in query
+    assert "repo_1" in query
+    assert 'owner: "vuejs"' in query
+
+
+def test_enrich_descriptions_success():
+    repos = [
+        {"url": "https://github.com/facebook/react", "stars": 200000},
+        {"url": "https://github.com/vuejs/vue", "stars": 180000},
+    ]
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "data": {
+            "repo_0": {
+                "stargazerCount": 200000,
+                "description": "A JavaScript library for building user interfaces",
+            },
+            "repo_1": {
+                "stargazerCount": 180000,
+                "description": "A progressive framework for building UIs",
+            },
+        }
+    }
+
+    mock_session = MagicMock()
+    mock_session.post.return_value = mock_response
+
+    result = enrich_descriptions(mock_session, repos, "fake-token")
+
+    assert len(result) == 2
+    assert result[0]["description"] == "A JavaScript library for building user interfaces"
+    assert result[1]["description"] == "A progressive framework for building UIs"
+    # Original repos should not be mutated
+    assert "description" not in repos[0]
+
+
+def test_enrich_descriptions_truncates_long_description():
+    repos = [{"url": "https://github.com/owner/repo", "stars": 100}]
+    long_desc = "A" * 100  # longer than 60 chars
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "data": {
+            "repo_0": {"stargazerCount": 100, "description": long_desc},
+        }
+    }
+
+    mock_session = MagicMock()
+    mock_session.post.return_value = mock_response
+
+    result = enrich_descriptions(mock_session, repos, "fake-token")
+    assert len(result[0]["description"]) <= 60
+
+
+def test_enrich_descriptions_handles_null_description():
+    repos = [{"url": "https://github.com/owner/repo", "stars": 100}]
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "data": {
+            "repo_0": {"stargazerCount": 100, "description": None},
+        }
+    }
+
+    mock_session = MagicMock()
+    mock_session.post.return_value = mock_response
+
+    result = enrich_descriptions(mock_session, repos, "fake-token")
+    assert result[0]["description"] == " "
+
+
+def test_enrich_descriptions_falls_back_on_http_error():
+    repos = [{"url": "https://github.com/owner/repo", "stars": 100}]
+
+    mock_response = MagicMock()
+    mock_response.status_code = 401
+
+    mock_session = MagicMock()
+    mock_session.post.return_value = mock_response
+
+    result = enrich_descriptions(mock_session, repos, "bad-token")
+    # Should return original repos unchanged
+    assert result is repos
+
+
+def test_enrich_descriptions_falls_back_on_network_error():
+    import requests
+
+    repos = [{"url": "https://github.com/owner/repo", "stars": 100}]
+
+    mock_session = MagicMock()
+    mock_session.post.side_effect = requests.RequestException("connection failed")
+
+    result = enrich_descriptions(mock_session, repos, "fake-token")
+    assert result is repos
+
+
+def test_enrich_descriptions_empty_list():
+    result = enrich_descriptions(MagicMock(), [], "fake-token")
+    assert result == []

--- a/tests/test_parse_dependent_counts.py
+++ b/tests/test_parse_dependent_counts.py
@@ -1,0 +1,69 @@
+from ghtopdep.ghtopdep import parse_dependent_counts
+
+
+SAMPLE_HTML = """
+<div class="table-list-header-toggle">
+  <a class="btn-link selected" href="/owner/repo/network/dependents?dependent_type=REPOSITORY">
+    2,295 Repositories
+  </a>
+  <a class="btn-link" href="/owner/repo/network/dependents?dependent_type=PACKAGE">
+    44 Packages
+  </a>
+</div>
+<div id="dependents">
+  <div class="Box">
+  </div>
+</div>
+"""
+
+
+def test_parses_both_counts():
+    counts = parse_dependent_counts(SAMPLE_HTML)
+    assert counts["REPOSITORY"] == 2295
+    assert counts["PACKAGE"] == 44
+
+
+def test_single_repository():
+    html = """
+    <div class="table-list-header-toggle">
+      <a class="btn-link selected" href="#">1 Repository</a>
+    </div>
+    """
+    counts = parse_dependent_counts(html)
+    assert counts["REPOSITORY"] == 1
+
+
+def test_single_package():
+    html = """
+    <div class="table-list-header-toggle">
+      <a class="btn-link" href="#">1 Package</a>
+    </div>
+    """
+    counts = parse_dependent_counts(html)
+    assert counts["PACKAGE"] == 1
+
+
+def test_large_numbers_with_commas():
+    html = """
+    <div class="table-list-header-toggle">
+      <a class="btn-link selected" href="#">1,234,567 Repositories</a>
+    </div>
+    """
+    counts = parse_dependent_counts(html)
+    assert counts["REPOSITORY"] == 1234567
+
+
+def test_returns_empty_dict_on_missing_elements():
+    html = "<html><body>nothing here</body></html>"
+    counts = parse_dependent_counts(html)
+    assert counts == {}
+
+
+def test_returns_empty_dict_on_malformed_text():
+    html = """
+    <div class="table-list-header-toggle">
+      <a class="btn-link" href="#">not a number Repositories</a>
+    </div>
+    """
+    counts = parse_dependent_counts(html)
+    assert counts == {}

--- a/tests/test_prefetch.py
+++ b/tests/test_prefetch.py
@@ -1,0 +1,95 @@
+import time
+from unittest.mock import MagicMock
+from ghtopdep.prefetch import PagePrefetcher
+from ghtopdep.rate_limiter import TokenBucketRateLimiter
+
+
+def _make_mock_session(pages):
+    """Create a mock session that returns canned HTML for each URL."""
+    session = MagicMock()
+
+    def fake_get(url):
+        resp = MagicMock()
+        resp.text = pages.get(url, "<html>not found</html>")
+        return resp
+
+    session.get.side_effect = fake_get
+    return session
+
+
+def test_get_without_submit_fetches_synchronously():
+    """When no prefetch was submitted, get() fetches the URL directly."""
+    session = _make_mock_session({"http://page1": "<html>page1</html>"})
+    limiter = TokenBucketRateLimiter(rate=100, period=1.0)
+    prefetcher = PagePrefetcher(session, limiter)
+
+    result = prefetcher.get("http://page1")
+    assert result == "<html>page1</html>"
+    session.get.assert_called_once_with("http://page1")
+    prefetcher.shutdown()
+
+
+def test_submit_then_get_returns_prefetched():
+    """Submit kicks off a background fetch; get() returns its result."""
+    pages = {
+        "http://page1": "<html>page1</html>",
+        "http://page2": "<html>page2</html>",
+    }
+    session = _make_mock_session(pages)
+    limiter = TokenBucketRateLimiter(rate=100, period=1.0)
+    prefetcher = PagePrefetcher(session, limiter)
+
+    prefetcher.submit("http://page2")
+    # Give the background thread a moment
+    time.sleep(0.1)
+    result = prefetcher.get("http://page2")
+    assert result == "<html>page2</html>"
+    prefetcher.shutdown()
+
+
+def test_submit_ignores_duplicate():
+    """Calling submit twice without a get in between is a no-op."""
+    pages = {"http://page1": "<html>page1</html>"}
+    session = _make_mock_session(pages)
+    limiter = TokenBucketRateLimiter(rate=100, period=1.0)
+    prefetcher = PagePrefetcher(session, limiter)
+
+    prefetcher.submit("http://page1")
+    prefetcher.submit("http://page1")  # should be ignored
+    time.sleep(0.1)
+    result = prefetcher.get("http://page1")
+    assert result == "<html>page1</html>"
+    # session.get should only be called once (the first submit)
+    session.get.assert_called_once_with("http://page1")
+    prefetcher.shutdown()
+
+
+def test_shutdown_is_safe_with_no_pending():
+    """Shutdown without any pending work should not raise."""
+    session = MagicMock()
+    limiter = TokenBucketRateLimiter(rate=100, period=1.0)
+    prefetcher = PagePrefetcher(session, limiter)
+    prefetcher.shutdown()  # should not raise
+
+
+def test_get_blocks_until_prefetch_completes():
+    """get() should block if prefetch is still in progress."""
+    def slow_get(url):
+        time.sleep(0.3)
+        resp = MagicMock()
+        resp.text = "<html>slow</html>"
+        return resp
+
+    session = MagicMock()
+    session.get.side_effect = slow_get
+    limiter = TokenBucketRateLimiter(rate=100, period=1.0)
+    prefetcher = PagePrefetcher(session, limiter)
+
+    prefetcher.submit("http://slow-page")
+    start = time.monotonic()
+    result = prefetcher.get("http://slow-page")
+    elapsed = time.monotonic() - start
+
+    assert result == "<html>slow</html>"
+    assert elapsed >= 0.2, "get() should have blocked waiting for the slow fetch"
+    prefetcher.shutdown()

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -1,0 +1,56 @@
+import time
+import threading
+from ghtopdep.rate_limiter import TokenBucketRateLimiter
+
+
+def test_acquire_consumes_token():
+    """First acquire should succeed instantly when bucket is full."""
+    limiter = TokenBucketRateLimiter(rate=10, period=1.0)
+    start = time.monotonic()
+    limiter.acquire()
+    elapsed = time.monotonic() - start
+    assert elapsed < 0.1, "First acquire should be near-instant"
+
+
+def test_acquire_blocks_when_empty():
+    """After exhausting tokens, acquire should block until refill."""
+    limiter = TokenBucketRateLimiter(rate=2, period=1.0)
+    limiter.acquire()
+    limiter.acquire()
+    # Bucket is now empty; next acquire should block ~0.5s (1 token / 2 per sec)
+    start = time.monotonic()
+    limiter.acquire()
+    elapsed = time.monotonic() - start
+    assert 0.3 < elapsed < 1.0, "Should block ~0.5s waiting for refill"
+
+
+def test_burst_up_to_rate():
+    """Should allow a burst of 'rate' requests without blocking."""
+    limiter = TokenBucketRateLimiter(rate=5, period=1.0)
+    start = time.monotonic()
+    for _ in range(5):
+        limiter.acquire()
+    elapsed = time.monotonic() - start
+    assert elapsed < 0.2, "Burst of 5 should complete near-instantly"
+
+
+def test_thread_safety():
+    """Multiple threads calling acquire should not overshoot the rate."""
+    limiter = TokenBucketRateLimiter(rate=4, period=1.0)
+    results = []
+
+    def worker():
+        limiter.acquire()
+        results.append(time.monotonic())
+
+    threads = [threading.Thread(target=worker) for _ in range(6)]
+    start = time.monotonic()
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=5)
+
+    # 4 should complete near-instantly, remaining 2 should be delayed
+    assert len(results) == 6
+    fast = [r for r in results if r - start < 0.2]
+    assert len(fast) == 4, "Exactly 4 tokens should be available immediately"


### PR DESCRIPTION
## Summary

Ports six internal enhancements from the [dep-rank](https://github.com/j7an/dep-rank) rewrite back into ghtopdep. All changes are invisible to end users — CLI flags, output format (tabulate/tqdm), and visible behavior are completely unchanged.

- **GraphQL batch enrichment:** `--description` now uses 1 GraphQL API call instead of N REST calls (one per repo via github3.py). Descriptions are fetched post-sort for only the display set.
- **Token bucket rate limiter:** Proactive request throttling (10 req/min unauthenticated, 60 req/min with token) instead of reactive retry-on-429.
- **Threaded prefetch pipeline:** Fetches page N+1 in a background thread while the main thread processes page N, using `concurrent.futures.ThreadPoolExecutor`.
- **`parse_dependent_counts`:** Extracts total dependent counts from the first page (already fetched) via regex, eliminating the extra HTTP request that `get_max_deps` made.
- **Set-based deduplication:** Replaces O(n²) `already_added()` linear scan with O(1) `set()` lookups.
- **Tuned retry config:** 5 retries with 5s exponential backoff (capped at 120s), now also retries on 500/502/503.

### Architecture

Three new helper modules (`rate_limiter.py`, `graphql_enrich.py`, `prefetch.py`) plus inline edits to `ghtopdep.py`. No new runtime dependencies — only stdlib additions (`threading`, `concurrent.futures`, `re`). pytest added as a dev dependency.

### Stats

- `ghtopdep.py`: 262 → 255 lines (net -7, simpler loop)
- New production code: 172 lines across 3 focused modules
- New tests: 23 tests across 4 test files
- No new runtime dependencies

## Test plan

- [x] 23 unit tests pass (`python -m pytest tests/ -v`)
- [x] All new modules import cleanly
- [x] CLI import (`from ghtopdep.ghtopdep import cli`) works
- [x] CLI `--help` output unchanged
- [ ] Manual smoke test: `ghtopdep https://github.com/pallets/flask --rows 5`
- [ ] Manual smoke test with `--description --token`: verify GraphQL enrichment